### PR TITLE
Add all basic tests from moustache specs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ subsequent parts only the result of the first part is searched and the enclosing
 
 ### Whitespace
 
-This implementation treats all whitespace as significant, and copies it to the output.
+Whitespace in lines that only contain a tag are ignored. All other whitespace are copied to the output.
 This includes the newline at the end of a file, so if, for example, you have a partial to substitute a word or phrase
 into the middle of a line, then to preserve line formatting the partial must not have a newline at the end of the file.
 
@@ -178,7 +178,7 @@ For example:
     data class Transaction(val type: Type, val amount: Int)
 
     val template = Template.parse("{{#type}}{{#CREDIT}}+{{/CREDIT}}{{#DEBIT}}-{{/DEBIT}}{{/type}}{{&amount}}")
-    println(template.render(Transaction(Type.DEBIT, 100))) // will print -100
+    println(template.processToString(Transaction(Type.DEBIT, 100))) // will print -100
 ```
 
 ## Dependency Specification

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.8</java.version>
+    <kotlin.version>1.6.20</kotlin.version>
   </properties>
 
   <licenses>
@@ -75,16 +76,24 @@
       <artifactId>kotlin-test-junit</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.snakeyaml</groupId>
+      <artifactId>snakeyaml-engine</artifactId>
+      <version>2.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.8.2</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
     <sourceDirectory>src/main/kotlin</sourceDirectory>
     <testSourceDirectory>src/test/kotlin</testSourceDirectory>
     <plugins>
-      <plugin>
-        <groupId>org.jetbrains.kotlin</groupId>
-        <artifactId>kotlin-maven-plugin</artifactId>
-      </plugin>
       <plugin>
         <groupId>org.jetbrains.dokka</groupId>
         <artifactId>dokka-maven-plugin</artifactId>

--- a/src/main/kotlin/net/pwall/mustache/Context.kt
+++ b/src/main/kotlin/net/pwall/mustache/Context.kt
@@ -63,6 +63,10 @@ open class Context private constructor(private val contextObject: Any?, private 
                 if (sourceObject.containsKey(name))
                     return sourceObject[name]
             }
+            is Map.Entry<*, *> -> {
+                if (sourceObject.key == name)
+                    return sourceObject.value
+            }
             else -> {
                 val kClass = sourceObject::class
                 kClass.memberProperties.find { it.name == name }?.let { return it.call(sourceObject) }

--- a/src/main/kotlin/net/pwall/mustache/Template.kt
+++ b/src/main/kotlin/net/pwall/mustache/Template.kt
@@ -140,11 +140,11 @@ class Template internal constructor(elements: List<Element>, indent: String = ""
                         appendChildren(appendable, context.child(value))
                 }
                 is Short -> {
-                    if (value != 0)
+                    if (value.toInt() != 0)
                         appendChildren(appendable, context.child(value))
                 }
                 is Byte -> {
-                    if (value != 0)
+                    if (value.toInt() != 0)
                         appendChildren(appendable, context.child(value))
                 }
                 is Double -> {
@@ -224,15 +224,15 @@ class Template internal constructor(elements: List<Element>, indent: String = ""
                             appendChildren(appendable, context)
                     }
                     is Long -> {
-                        if (it == 0)
+                        if (it == 0L)
                             appendChildren(appendable, context)
                     }
                     is Short -> {
-                        if (it == 0)
+                        if (it.toInt() == 0)
                             appendChildren(appendable, context)
                     }
                     is Byte -> {
-                        if (it == 0)
+                        if (it.toInt() == 0)
                             appendChildren(appendable, context)
                     }
                 }

--- a/src/main/kotlin/net/pwall/mustache/parser/MustacheReader.kt
+++ b/src/main/kotlin/net/pwall/mustache/parser/MustacheReader.kt
@@ -1,0 +1,116 @@
+/*
+ * @(#) MustacheReader.kt
+ *
+ * kotlin-mustache  Kotlin implementation of Mustache templates
+ * Copyright (c) 2020 Peter Wall
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.pwall.mustache.parser
+
+import java.io.Reader
+
+/**
+ * A Reader that ignores whitespace surrounding standalone tags.
+ *
+ * Comments are also entirely dropped.
+ */
+class MustacheReader(
+        val input: Reader,
+        val maxLineSize: Int = DEFAULT_MAX_LINE_SIZE
+) : Reader() {
+
+    private val lineBuffer = CharArray(maxLineSize)
+    private var pos = 0
+    private var end = 0
+    private var openDelimiter = defaultOpenDelimiter
+    private var closeDelimiter = defaultCloseDelimiter
+
+    var indent: String = ""
+
+    override fun read(cbuf: CharArray, off: Int, len: Int): Int {
+        var cnt = 0
+        do {
+            if (pos == end) {
+                loadLineBuffer()
+            }
+            while (cnt < len && pos < end) {
+                cbuf[off + cnt++] = lineBuffer[pos++]
+            }
+        } while (end > 0 && cnt < len)
+        return if (cnt == 0) -1 else cnt
+    }
+
+    override fun close() {
+        input.close()
+    }
+
+    fun setDelimiter(openDelimiter: String, closeDelimiter: String) {
+        this.openDelimiter = openDelimiter
+        this.closeDelimiter = closeDelimiter
+    }
+
+    private fun loadLineBuffer() {
+        pos = 0
+        end = 0
+        var inComment = false
+        val commentStart = "$openDelimiter!"
+        do {
+            val st = input.read(lineBuffer, end, 1)
+            if (st == 1) {
+                if (!inComment) {
+                    end++
+                    if (end >= commentStart.length &&
+                            String(lineBuffer, end - commentStart.length, commentStart.length) == commentStart) {
+                        inComment = true
+                    }
+                } else if (lineBuffer[end] == closeDelimiter[0]) {
+                    input.read(lineBuffer, end + 1, closeDelimiter.length - 1)
+                    if (String(lineBuffer, end, closeDelimiter.length) == closeDelimiter) {
+                        inComment = false
+                        end += closeDelimiter.length
+                    }
+                }
+            }
+        } while (st != -1 && (end == 0 || lineBuffer[end - 1] != '\n') && end < maxLineSize)
+
+        if (end == maxLineSize && lineBuffer[maxLineSize - 1] != '\n')
+            throw MustacheParserException("Line buffer overflow")
+
+        val line = String(lineBuffer, 0, end)
+        val trimmed = line.trim()
+        val unwrapped = trimmed.removeSurrounding(openDelimiter, closeDelimiter)
+        val isWrapped = unwrapped.length != trimmed.length
+        val isSingleTag = isWrapped && unwrapped[0] in tagType && closeDelimiter !in unwrapped
+        if (isSingleTag) {
+            trimmed.forEachIndexed { idx, c -> lineBuffer[idx] = c }
+            end = trimmed.length
+            indent = line.split(openDelimiter, limit = 2).first()
+        }
+    }
+
+    companion object {
+        const val DEFAULT_MAX_LINE_SIZE = 1024
+
+        private const val tagType = "#^/>=!"
+        private const val defaultOpenDelimiter = "{{"
+        private const val defaultCloseDelimiter = "}}"
+    }
+}

--- a/src/main/kotlin/net/pwall/mustache/parser/Parser.kt
+++ b/src/main/kotlin/net/pwall/mustache/parser/Parser.kt
@@ -31,18 +31,26 @@ import java.io.Reader
 import java.io.StringReader
 
 import net.pwall.mustache.Template
+import java.io.FileNotFoundException
 
 class Parser(
         var directory: File = File("."),
         var extension: String = "mustache",
-        var resolvePartial: Parser.(String) -> Reader =
-                { name -> File(this.directory, "$name.${this.extension}").reader() }
+        var resolvePartial: Parser.(String) -> Reader = { name ->
+            try {
+                File(this.directory, "$name.${this.extension}").reader()
+            } catch (_: FileNotFoundException) {
+                StringReader("")
+            }
+        }
 ) {
 
     private var openDelimiter = "{{"
     private var closeDelimiter = "}}"
 
-    private val partialCache = mutableMapOf<String, Template.Partial>()
+    private val partialCache = mutableMapOf<String, Template>()
+
+    fun clearPartials() = partialCache.clear()
 
     fun parse(file: File): Template {
         directory = file.parentFile
@@ -55,12 +63,12 @@ class Parser(
     fun parse(reader: Reader): Template {
         openDelimiter = defaultOpenDelimiter
         closeDelimiter = defaultCloseDelimiter
-        return Template(parseNested(reader.buffered()))
+        return Template(parseNested(MustacheReader(reader.buffered())))
     }
 
     fun parse(string: String): Template = parse(StringReader(string))
 
-    private fun parseNested(reader: Reader, stopper: String? = null): List<Template.Element> {
+    private fun parseNested(reader: MustacheReader, stopper: String? = null): List<Template.Element> {
         val saveOpenDelimiter = openDelimiter
         val saveCloseDelimiter = closeDelimiter
         try {
@@ -106,10 +114,14 @@ class Parser(
                                 }
                                 '>' -> {
                                     val name = tag.substring(1).trim()
-                                    val partial = getPartial(name)
-                                    elements.add(partial)
+                                    elements.add(
+                                            Template.Partial({ getPartial(name) }, reader.indent)
+                                    )
                                 }
-                                '=' -> setDelimiters(tag)
+                                '=' -> {
+                                    setDelimiters(tag)
+                                    reader.setDelimiter(openDelimiter, closeDelimiter)
+                                }
                                 '!' -> {}
                                 else -> elements.add(Template.Variable(tag))
                             }
@@ -141,11 +153,11 @@ class Parser(
         throw MustacheParserException("Incorrect delimiter tag")
     }
 
-    private fun getPartial(name: String): Template.Partial {
-        return partialCache[name] ?: Template.Partial().also {
-            partialCache[name] = it
-            resolvePartial(name).use { reader ->
-                it.template = parse(reader)
+    private fun getPartial(name: String): Template {
+        return partialCache[name] ?: resolvePartial(name).use { reader ->
+            partialCache[name] = Template(emptyList())
+            parse(reader).also {
+                partialCache[name]!!.elements = it.elements
             }
         }
     }

--- a/src/main/kotlin/net/pwall/mustache/parser/Parser.kt
+++ b/src/main/kotlin/net/pwall/mustache/parser/Parser.kt
@@ -144,7 +144,9 @@ class Parser(
     private fun getPartial(name: String): Template.Partial {
         return partialCache[name] ?: Template.Partial().also {
             partialCache[name] = it
-            it.template = parse(resolvePartial(name))
+            resolvePartial(name).use { reader ->
+                it.template = parse(reader)
+            }
         }
     }
 

--- a/src/test/kotlin/net/pwall/mustache/MustacheReaderTest.kt
+++ b/src/test/kotlin/net/pwall/mustache/MustacheReaderTest.kt
@@ -1,0 +1,144 @@
+/*
+ * @(#) MustacheReaderTest.kt
+ *
+ * kotlin-mustache  Kotlin implementation of Mustache templates
+ * Copyright (c) 2020 Peter Wall
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.pwall.mustache
+
+import net.pwall.mustache.parser.MustacheParserException
+import net.pwall.mustache.parser.MustacheReader
+import java.io.StringReader
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.expect
+
+
+class MustacheReaderTest {
+
+    private val buffer = CharArray(1024)
+
+    @Test
+    fun `reader on empty data is eof`() {
+        val reader = MustacheReader(StringReader(""))
+        expect(-1) { reader.read(buffer, 0, 1) }
+    }
+
+    @Test
+    fun `reader for text is transparent and keeps LF`() {
+        val text = "xxx\n"
+        val reader = MustacheReader(StringReader(text))
+        expect(4) { reader.read(buffer, 0, 4) }
+        expect(-1) { reader.read(buffer, 0, 1) }
+        expect(text) { String(buffer, 0, 4) }
+    }
+
+    @Test
+    fun `reader for text is transparent and keeps CRLF`() {
+        val text = "xxx\r\n"
+        val reader = MustacheReader(StringReader(text))
+        expect(1) { reader.read(buffer, 0, 1) }
+        expect(1) { reader.read(buffer, 1, 1) }
+        expect(1) { reader.read(buffer, 2, 1) }
+        expect(1) { reader.read(buffer, 3, 1) }
+        expect(1) { reader.read(buffer, 4, 1) }
+        expect(-1) { reader.read(buffer, 0, 1) }
+        expect(text) { String(buffer, 0, 5) }
+    }
+
+    @Test
+    fun `reader reads less than requested on EOF`() {
+        val text = "12345678"
+        val reader = MustacheReader(StringReader(text))
+        expect(8) { reader.read(buffer, 0, 10) }
+        expect(-1) { reader.read(buffer, 0, 1) }
+        expect(text) { String(buffer, 0, 8) }
+    }
+
+    @Test
+    fun `section tag after data keeps whitespaces`() {
+        val text = "#  {{#xxx}}  \n"
+        val reader = MustacheReader(StringReader(text))
+        val len = reader.read(buffer, 0, 1024)
+        expect(text) { String(buffer, 0, len) }
+    }
+
+    @Test
+    fun `section tag before data keeps whitespaces`() {
+        val text = "  {{#xxx}}  #\n"
+        val reader = MustacheReader(StringReader(text))
+        val len = reader.read(buffer, 0, 1024)
+        expect(text) { String(buffer, 0, len) }
+    }
+
+    @Test
+    fun `standalone section tag in regular line is trimmed`() {
+        val tag = "{{#xxx}}"
+        val text = "  $tag  \n"
+        val reader = MustacheReader(StringReader(text))
+        val len = reader.read(buffer, 0, 1024)
+        expect(tag) { String(buffer, 0, len) }
+    }
+
+    @Test
+    fun `standalone section tag on eof is trimmed`() {
+        val tag = "{{/xxx}}"
+        val text = "  $tag  "
+        val reader = MustacheReader(StringReader(text))
+        val len = reader.read(buffer, 0, 1024)
+        expect(tag) { String(buffer, 0, len) }
+    }
+
+    @Test
+    fun `reader accepts multi line comment`() {
+        val text = " {{!\n xxx}\n yyy}\nzzz\n }} "
+        val reader = MustacheReader(StringReader(text))
+        val len = reader.read(buffer, 0, 1024)
+        expect("{{!}}") { String(buffer, 0, len) }
+    }
+
+    @Test
+    fun `line buffer overflow triggers exception`() {
+        // second line causes overflow
+        val text = "12345\n123456\n123"
+        val reader = MustacheReader(StringReader(text), 6)
+        assertFailsWith<MustacheParserException> {
+            reader.read(buffer, 0, 50)
+        }
+    }
+
+    @Test
+    fun `standalone data item keeps whitespace`() {
+        val text = "  {{{xxx}}}  "
+        val reader = MustacheReader(StringReader(text))
+        val len = reader.read(buffer, 0, 1024)
+        expect(text) { String(buffer, 0, len) }
+    }
+
+    @Test
+    fun `two tags on same line are not collapsed`() {
+        val text = "{{#xxx}} {{/xxx}}"
+        val reader = MustacheReader(StringReader(text))
+        val len = reader.read(buffer, 0, 1024)
+        expect(text) { String(buffer, 0, len) }
+    }
+}

--- a/src/test/kotlin/net/pwall/mustache/specs/SpecsTest.kt
+++ b/src/test/kotlin/net/pwall/mustache/specs/SpecsTest.kt
@@ -1,0 +1,122 @@
+/*
+ * @(#) SpecsTest.kt
+ *
+ * kotlin-mustache  Kotlin implementation of Mustache templates
+ * Copyright (c) 2020 Peter Wall
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.pwall.mustache.specs
+
+import net.pwall.mustache.Template
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
+import org.snakeyaml.engine.v2.api.Load
+import org.snakeyaml.engine.v2.api.LoadSettings
+import java.io.Closeable
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.expect
+
+
+class SpecsTest {
+
+    @TestFactory
+    fun `comments tests`() =
+        makeTests("comments.yml")
+
+    @TestFactory
+    fun `delimiters tests`() =
+        makeTests("delimiters.yml")
+
+    @TestFactory
+    fun `interpolation tests`() =
+        makeTests("interpolation.yml")
+
+    @TestFactory
+    fun `inverted tests`() =
+        makeTests("inverted.yml")
+
+    @TestFactory
+    fun `partials tests`() =
+        makeTests("partials.yml")
+
+    @TestFactory
+    fun `sections tests`() =
+        makeTests("sections.yml")
+
+    @TestFactory
+    fun `additional tests`() =
+        makeTests("~additional.yml")
+}
+
+
+@Suppress("UNCHECKED_CAST")
+private fun makeTests(fileName: String) =
+    File("src/test/resources/specs/$fileName").inputStream().use {
+        yamlLoader.loadFromInputStream(it)
+    }.let { top ->
+        val spec = top as Map<*, *>
+        val tests = spec["tests"] as List<*>
+        tests.map { inner ->
+            val test = inner as Map<*, *>
+            makeSingleTest(
+                name = test["name"] as String,
+                desc = test["desc"] as String,
+                template = test["template"] as String,
+                partials = test["partials"]?.let { it as Map<String, String> } ?: emptyMap(),
+                data = test["data"] as Any,
+                expected = test["expected"] as String
+            )
+        }
+    }
+
+private val yamlLoader = Load(LoadSettings.builder().build())
+
+private fun makeSingleTest(
+    name: String,
+    desc: String,
+    template: String,
+    partials: Map<String, String>,
+    data: Any,
+    expected: String
+) = DynamicTest.dynamicTest("$name: $desc") {
+    PartialEnv(partials).use { partialEnv ->
+        Template.clearPartials()
+        Template.parser.directory = partialEnv.directory
+        expect(expected) {
+            Template.parse(template).processToString(data)
+        }
+    }
+}
+
+
+private class PartialEnv(partials: Map<String, String>) : Closeable {
+    val directory: File = createTempDirectory("partials").toFile().also {
+        partials.forEach { (name, content) ->
+            File("$it/$name.mustache").writeText(content)
+        }
+    }
+
+    override fun close() {
+        directory.deleteRecursively()
+    }
+}

--- a/src/test/resources/specs/comments.yml
+++ b/src/test/resources/specs/comments.yml
@@ -1,0 +1,103 @@
+overview: |
+  Comment tags represent content that should never appear in the resulting
+  output.
+
+  The tag's content may contain any substring (including newlines) EXCEPT the
+  closing delimiter.
+
+  Comment tags SHOULD be treated as standalone when appropriate.
+tests:
+  - name: Inline
+    desc: Comment blocks should be removed from the template.
+    data: { }
+    template: '12345{{! Comment Block! }}67890'
+    expected: '1234567890'
+
+  - name: Multiline
+    desc: Multiline comments should be permitted.
+    data: { }
+    template: |
+      12345{{!
+        This is a
+        multi-line comment...
+      }}67890
+    expected: |
+      1234567890
+
+  - name: Standalone
+    desc: All standalone comment lines should be removed.
+    data: { }
+    template: |
+      Begin.
+      {{! Comment Block! }}
+      End.
+    expected: |
+      Begin.
+      End.
+
+  - name: Indented Standalone
+    desc: All standalone comment lines should be removed.
+    data: { }
+    template: |
+      Begin.
+        {{! Indented Comment Block! }}
+      End.
+    expected: |
+      Begin.
+      End.
+
+  - name: Standalone Line Endings
+    desc: '"\r\n" should be considered a newline for standalone tags.'
+    data: { }
+    template: "|\r\n{{! Standalone Comment }}\r\n|"
+    expected: "|\r\n|"
+
+  - name: Standalone Without Previous Line
+    desc: Standalone tags should not require a newline to precede them.
+    data: { }
+    template: "  {{! I'm Still Standalone }}\n!"
+    expected: "!"
+
+  - name: Standalone Without Newline
+    desc: Standalone tags should not require a newline to follow them.
+    data: { }
+    template: "!\n  {{! I'm Still Standalone }}"
+    expected: "!\n"
+
+  - name: Multiline Standalone
+    desc: All standalone comment lines should be removed.
+    data: { }
+    template: |
+      Begin.
+      {{!
+      Something's going on here...
+      }}
+      End.
+    expected: |
+      Begin.
+      End.
+
+  - name: Indented Multiline Standalone
+    desc: All standalone comment lines should be removed.
+    data: { }
+    template: |
+      Begin.
+        {{!
+          Something's going on here...
+        }}
+      End.
+    expected: |
+      Begin.
+      End.
+
+  - name: Indented Inline
+    desc: Inline comments should not strip whitespace
+    data: { }
+    template: "  12 {{! 34 }}\n"
+    expected: "  12 \n"
+
+  - name: Surrounding Whitespace
+    desc: Comment removal should preserve surrounding whitespace.
+    data: { }
+    template: '12345 {{! Comment Block! }} 67890'
+    expected: '12345  67890'

--- a/src/test/resources/specs/delimiters.yml
+++ b/src/test/resources/specs/delimiters.yml
@@ -1,0 +1,158 @@
+overview: |
+  Set Delimiter tags are used to change the tag delimiters for all content
+  following the tag in the current compilation unit.
+
+  The tag's content MUST be any two non-whitespace sequences (separated by
+  whitespace) EXCEPT an equals sign ('=') followed by the current closing
+  delimiter.
+
+  Set Delimiter tags SHOULD be treated as standalone when appropriate.
+tests:
+  - name: Pair Behavior
+    desc: The equals sign (used on both sides) should permit delimiter changes.
+    data: { text: 'Hey!' }
+    template: '{{=<% %>=}}(<%text%>)'
+    expected: '(Hey!)'
+
+  - name: Special Characters
+    desc: Characters with special meaning regexen should be valid delimiters.
+    data: { text: 'It worked!' }
+    template: '({{=[ ]=}}[text])'
+    expected: '(It worked!)'
+
+  - name: Sections
+    desc: Delimiters set outside sections should persist.
+    data: { section: true, data: 'I got interpolated.' }
+    template: |
+      [
+      {{#section}}
+        {{data}}
+        |data|
+      {{/section}}
+
+      {{= | | =}}
+      |#section|
+        {{data}}
+        |data|
+      |/section|
+      ]
+    expected: |
+      [
+        I got interpolated.
+        |data|
+
+        {{data}}
+        I got interpolated.
+      ]
+
+  - name: Inverted Sections
+    desc: Delimiters set outside inverted sections should persist.
+    data: { section: false, data: 'I got interpolated.' }
+    template: |
+      [
+      {{^section}}
+        {{data}}
+        |data|
+      {{/section}}
+
+      {{= | | =}}
+      |^section|
+        {{data}}
+        |data|
+      |/section|
+      ]
+    expected: |
+      [
+        I got interpolated.
+        |data|
+
+        {{data}}
+        I got interpolated.
+      ]
+
+  - name: Partial Inheritence
+    desc: Delimiters set in a parent template should not affect a partial.
+    data: { value: 'yes' }
+    partials:
+      include: '.{{value}}.'
+    template: |
+      [ {{>include}} ]
+      {{= | | =}}
+      [ |>include| ]
+    expected: |
+      [ .yes. ]
+      [ .yes. ]
+
+  - name: Post-Partial Behavior
+    desc: Delimiters set in a partial should not affect the parent template.
+    data: { value: 'yes' }
+    partials:
+      include: '.{{value}}. {{= | | =}} .|value|.'
+    template: |
+      [ {{>include}} ]
+      [ .{{value}}.  .|value|. ]
+    expected: |
+      [ .yes.  .yes. ]
+      [ .yes.  .|value|. ]
+
+  # Whitespace Sensitivity
+
+  - name: Surrounding Whitespace
+    desc: Surrounding whitespace should be left untouched.
+    data: { }
+    template: '| {{=@ @=}} |'
+    expected: '|  |'
+
+  - name: Outlying Whitespace (Inline)
+    desc: Whitespace should be left untouched.
+    data: { }
+    template: " | {{=@ @=}}\n"
+    expected: " | \n"
+
+  - name: Standalone Tag
+    desc: Standalone lines should be removed from the template.
+    data: { }
+    template: |
+      Begin.
+      {{=@ @=}}
+      End.
+    expected: |
+      Begin.
+      End.
+
+  - name: Indented Standalone Tag
+    desc: Indented standalone lines should be removed from the template.
+    data: { }
+    template: |
+      Begin.
+        {{=@ @=}}
+      End.
+    expected: |
+      Begin.
+      End.
+
+  - name: Standalone Line Endings
+    desc: '"\r\n" should be considered a newline for standalone tags.'
+    data: { }
+    template: "|\r\n{{= @ @ =}}\r\n|"
+    expected: "|\r\n|"
+
+  - name: Standalone Without Previous Line
+    desc: Standalone tags should not require a newline to precede them.
+    data: { }
+    template: "  {{=@ @=}}\n="
+    expected: "="
+
+  - name: Standalone Without Newline
+    desc: Standalone tags should not require a newline to follow them.
+    data: { }
+    template: "=\n  {{=@ @=}}"
+    expected: "=\n"
+
+  # Whitespace Insensitivity
+
+  - name: Pair with Padding
+    desc: Superfluous in-tag whitespace should be ignored.
+    data: { }
+    template: '|{{= @   @ =}}|'
+    expected: '||'

--- a/src/test/resources/specs/interpolation.yml
+++ b/src/test/resources/specs/interpolation.yml
@@ -1,0 +1,296 @@
+overview: |
+  Interpolation tags are used to integrate dynamic content into the template.
+
+  The tag's content MUST be a non-whitespace character sequence NOT containing
+  the current closing delimiter.
+
+  This tag's content names the data to replace the tag.  A single period (`.`)
+  indicates that the item currently sitting atop the context stack should be
+  used; otherwise, name resolution is as follows:
+    1) Split the name on periods; the first part is the name to resolve, any
+    remaining parts should be retained.
+    2) Walk the context stack from top to bottom, finding the first context
+    that is a) a hash containing the name as a key OR b) an object responding
+    to a method with the given name.
+    3) If the context is a hash, the data is the value associated with the
+    name.
+    4) If the context is an object, the data is the value returned by the
+    method with the given name.
+    5) If any name parts were retained in step 1, each should be resolved
+    against a context stack containing only the result from the former
+    resolution.  If any part fails resolution, the result should be considered
+    falsey, and should interpolate as the empty string.
+  Data should be coerced into a string (and escaped, if appropriate) before
+  interpolation.
+
+  The Interpolation tags MUST NOT be treated as standalone.
+tests:
+  - name: No Interpolation
+    desc: Mustache-free templates should render as-is.
+    data: { }
+    template: |
+      Hello from {Mustache}!
+    expected: |
+      Hello from {Mustache}!
+
+  - name: Basic Interpolation
+    desc: Unadorned tags should interpolate content into the template.
+    data: { subject: "world" }
+    template: |
+      Hello, {{subject}}!
+    expected: |
+      Hello, world!
+
+  - name: HTML Escaping
+    desc: Basic interpolation should be HTML escaped.
+    data: { forbidden: '& " < >' }
+    template: |
+      These characters should be HTML escaped: {{forbidden}}
+    expected: |
+      These characters should be HTML escaped: &amp; &quot; &lt; &gt;
+
+  - name: Triple Mustache
+    desc: Triple mustaches should interpolate without HTML escaping.
+    data: { forbidden: '& " < >' }
+    template: |
+      These characters should not be HTML escaped: {{{forbidden}}}
+    expected: |
+      These characters should not be HTML escaped: & " < >
+
+  - name: Ampersand
+    desc: Ampersand should interpolate without HTML escaping.
+    data: { forbidden: '& " < >' }
+    template: |
+      These characters should not be HTML escaped: {{&forbidden}}
+    expected: |
+      These characters should not be HTML escaped: & " < >
+
+  - name: Basic Integer Interpolation
+    desc: Integers should interpolate seamlessly.
+    data: { mph: 85 }
+    template: '"{{mph}} miles an hour!"'
+    expected: '"85 miles an hour!"'
+
+  - name: Triple Mustache Integer Interpolation
+    desc: Integers should interpolate seamlessly.
+    data: { mph: 85 }
+    template: '"{{{mph}}} miles an hour!"'
+    expected: '"85 miles an hour!"'
+
+  - name: Ampersand Integer Interpolation
+    desc: Integers should interpolate seamlessly.
+    data: { mph: 85 }
+    template: '"{{&mph}} miles an hour!"'
+    expected: '"85 miles an hour!"'
+
+  - name: Basic Decimal Interpolation
+    desc: Decimals should interpolate seamlessly with proper significance.
+    data: { power: 1.210 }
+    template: '"{{power}} jiggawatts!"'
+    expected: '"1.21 jiggawatts!"'
+
+  - name: Triple Mustache Decimal Interpolation
+    desc: Decimals should interpolate seamlessly with proper significance.
+    data: { power: 1.210 }
+    template: '"{{{power}}} jiggawatts!"'
+    expected: '"1.21 jiggawatts!"'
+
+  - name: Ampersand Decimal Interpolation
+    desc: Decimals should interpolate seamlessly with proper significance.
+    data: { power: 1.210 }
+    template: '"{{&power}} jiggawatts!"'
+    expected: '"1.21 jiggawatts!"'
+
+  - name: Basic Null Interpolation
+    desc: Nulls should interpolate as the empty string.
+    data: { cannot: null }
+    template: "I ({{cannot}}) be seen!"
+    expected: "I () be seen!"
+
+  - name: Triple Mustache Null Interpolation
+    desc: Nulls should interpolate as the empty string.
+    data: { cannot: null }
+    template: "I ({{{cannot}}}) be seen!"
+    expected: "I () be seen!"
+
+  - name: Ampersand Null Interpolation
+    desc: Nulls should interpolate as the empty string.
+    data: { cannot: null }
+    template: "I ({{&cannot}}) be seen!"
+    expected: "I () be seen!"
+
+  # Context Misses
+
+  - name: Basic Context Miss Interpolation
+    desc: Failed context lookups should default to empty strings.
+    data: { }
+    template: "I ({{cannot}}) be seen!"
+    expected: "I () be seen!"
+
+  - name: Triple Mustache Context Miss Interpolation
+    desc: Failed context lookups should default to empty strings.
+    data: { }
+    template: "I ({{{cannot}}}) be seen!"
+    expected: "I () be seen!"
+
+  - name: Ampersand Context Miss Interpolation
+    desc: Failed context lookups should default to empty strings.
+    data: { }
+    template: "I ({{&cannot}}) be seen!"
+    expected: "I () be seen!"
+
+  # Dotted Names
+
+  - name: Dotted Names - Basic Interpolation
+    desc: Dotted names should be considered a form of shorthand for sections.
+    data: { person: { name: 'Joe' } }
+    template: '"{{person.name}}" == "{{#person}}{{name}}{{/person}}"'
+    expected: '"Joe" == "Joe"'
+
+  - name: Dotted Names - Triple Mustache Interpolation
+    desc: Dotted names should be considered a form of shorthand for sections.
+    data: { person: { name: 'Joe' } }
+    template: '"{{{person.name}}}" == "{{#person}}{{{name}}}{{/person}}"'
+    expected: '"Joe" == "Joe"'
+
+  - name: Dotted Names - Ampersand Interpolation
+    desc: Dotted names should be considered a form of shorthand for sections.
+    data: { person: { name: 'Joe' } }
+    template: '"{{&person.name}}" == "{{#person}}{{&name}}{{/person}}"'
+    expected: '"Joe" == "Joe"'
+
+  - name: Dotted Names - Arbitrary Depth
+    desc: Dotted names should be functional to any level of nesting.
+    data:
+      a: { b: { c: { d: { e: { name: 'Phil' } } } } }
+    template: '"{{a.b.c.d.e.name}}" == "Phil"'
+    expected: '"Phil" == "Phil"'
+
+  - name: Dotted Names - Broken Chains
+    desc: Any falsey value prior to the last part of the name should yield ''.
+    data:
+      a: { }
+    template: '"{{a.b.c}}" == ""'
+    expected: '"" == ""'
+
+  - name: Dotted Names - Broken Chain Resolution
+    desc: Each part of a dotted name should resolve only against its parent.
+    data:
+      a: { b: { } }
+      c: { name: 'Jim' }
+    template: '"{{a.b.c.name}}" == ""'
+    expected: '"" == ""'
+
+  - name: Dotted Names - Initial Resolution
+    desc: The first part of a dotted name should resolve as any other name.
+    data:
+      a: { b: { c: { d: { e: { name: 'Phil' } } } } }
+      b: { c: { d: { e: { name: 'Wrong' } } } }
+    template: '"{{#a}}{{b.c.d.e.name}}{{/a}}" == "Phil"'
+    expected: '"Phil" == "Phil"'
+
+  - name: Dotted Names - Context Precedence
+    desc: Dotted names should be resolved against former resolutions.
+    data:
+      a: { b: { } }
+      b: { c: 'ERROR' }
+    template: '{{#a}}{{b.c}}{{/a}}'
+    expected: ''
+
+  # Implicit Iterators
+
+  - name: Implicit Iterators - Basic Interpolation
+    desc: Unadorned tags should interpolate content into the template.
+    data: "world"
+    template: |
+      Hello, {{.}}!
+    expected: |
+      Hello, world!
+
+  - name: Implicit Iterators - HTML Escaping
+    desc: Basic interpolation should be HTML escaped.
+    data: '& " < >'
+    template: |
+      These characters should be HTML escaped: {{.}}
+    expected: |
+      These characters should be HTML escaped: &amp; &quot; &lt; &gt;
+
+  - name: Implicit Iterators - Triple Mustache
+    desc: Triple mustaches should interpolate without HTML escaping.
+    data: '& " < >'
+    template: |
+      These characters should not be HTML escaped: {{{.}}}
+    expected: |
+      These characters should not be HTML escaped: & " < >
+
+  - name: Implicit Iterators - Ampersand
+    desc: Ampersand should interpolate without HTML escaping.
+    data: '& " < >'
+    template: |
+      These characters should not be HTML escaped: {{&.}}
+    expected: |
+      These characters should not be HTML escaped: & " < >
+
+  - name: Implicit Iterators - Basic Integer Interpolation
+    desc: Integers should interpolate seamlessly.
+    data: 85
+    template: '"{{.}} miles an hour!"'
+    expected: '"85 miles an hour!"'
+
+  # Whitespace Sensitivity
+
+  - name: Interpolation - Surrounding Whitespace
+    desc: Interpolation should not alter surrounding whitespace.
+    data: { string: '---' }
+    template: '| {{string}} |'
+    expected: '| --- |'
+
+  - name: Triple Mustache - Surrounding Whitespace
+    desc: Interpolation should not alter surrounding whitespace.
+    data: { string: '---' }
+    template: '| {{{string}}} |'
+    expected: '| --- |'
+
+  - name: Ampersand - Surrounding Whitespace
+    desc: Interpolation should not alter surrounding whitespace.
+    data: { string: '---' }
+    template: '| {{&string}} |'
+    expected: '| --- |'
+
+  - name: Interpolation - Standalone
+    desc: Standalone interpolation should not alter surrounding whitespace.
+    data: { string: '---' }
+    template: "  {{string}}\n"
+    expected: "  ---\n"
+
+  - name: Triple Mustache - Standalone
+    desc: Standalone interpolation should not alter surrounding whitespace.
+    data: { string: '---' }
+    template: "  {{{string}}}\n"
+    expected: "  ---\n"
+
+  - name: Ampersand - Standalone
+    desc: Standalone interpolation should not alter surrounding whitespace.
+    data: { string: '---' }
+    template: "  {{&string}}\n"
+    expected: "  ---\n"
+
+  # Whitespace Insensitivity
+
+  - name: Interpolation With Padding
+    desc: Superfluous in-tag whitespace should be ignored.
+    data: { string: "---" }
+    template: '|{{ string }}|'
+    expected: '|---|'
+
+  - name: Triple Mustache With Padding
+    desc: Superfluous in-tag whitespace should be ignored.
+    data: { string: "---" }
+    template: '|{{{ string }}}|'
+    expected: '|---|'
+
+  - name: Ampersand With Padding
+    desc: Superfluous in-tag whitespace should be ignored.
+    data: { string: "---" }
+    template: '|{{& string }}|'
+    expected: '|---|'

--- a/src/test/resources/specs/inverted.yml
+++ b/src/test/resources/specs/inverted.yml
@@ -1,0 +1,199 @@
+overview: |
+  Inverted Section tags and End Section tags are used in combination to wrap a
+  section of the template.
+
+  These tags' content MUST be a non-whitespace character sequence NOT
+  containing the current closing delimiter; each Inverted Section tag MUST be
+  followed by an End Section tag with the same content within the same
+  section.
+
+  This tag's content names the data to replace the tag.  Name resolution is as
+  follows:
+    1) Split the name on periods; the first part is the name to resolve, any
+    remaining parts should be retained.
+    2) Walk the context stack from top to bottom, finding the first context
+    that is a) a hash containing the name as a key OR b) an object responding
+    to a method with the given name.
+    3) If the context is a hash, the data is the value associated with the
+    name.
+    4) If the context is an object and the method with the given name has an
+    arity of 1, the method SHOULD be called with a String containing the
+    unprocessed contents of the sections; the data is the value returned.
+    5) Otherwise, the data is the value returned by calling the method with
+    the given name.
+    6) If any name parts were retained in step 1, each should be resolved
+    against a context stack containing only the result from the former
+    resolution.  If any part fails resolution, the result should be considered
+    falsey, and should interpolate as the empty string.
+  If the data is not of a list type, it is coerced into a list as follows: if
+  the data is truthy (e.g. `!!data == true`), use a single-element list
+  containing the data, otherwise use an empty list.
+
+  This section MUST NOT be rendered unless the data list is empty.
+
+  Inverted Section and End Section tags SHOULD be treated as standalone when
+  appropriate.
+tests:
+  - name: Falsey
+    desc: Falsey sections should have their contents rendered.
+    data: { boolean: false }
+    template: '"{{^boolean}}This should be rendered.{{/boolean}}"'
+    expected: '"This should be rendered."'
+
+  - name: Truthy
+    desc: Truthy sections should have their contents omitted.
+    data: { boolean: true }
+    template: '"{{^boolean}}This should not be rendered.{{/boolean}}"'
+    expected: '""'
+
+  - name: Null is falsey
+    desc: Null is falsey.
+    data: { "null": null }
+    template: '"{{^null}}This should be rendered.{{/null}}"'
+    expected: '"This should be rendered."'
+
+  - name: Context
+    desc: Objects and hashes should behave like truthy values.
+    data: { context: { name: 'Joe' } }
+    template: '"{{^context}}Hi {{name}}.{{/context}}"'
+    expected: '""'
+
+  - name: List
+    desc: Lists should behave like truthy values.
+    data: { list: [ { n: 1 }, { n: 2 }, { n: 3 } ] }
+    template: '"{{^list}}{{n}}{{/list}}"'
+    expected: '""'
+
+  - name: Empty List
+    desc: Empty lists should behave like falsey values.
+    data: { list: [ ] }
+    template: '"{{^list}}Yay lists!{{/list}}"'
+    expected: '"Yay lists!"'
+
+  - name: Doubled
+    desc: Multiple inverted sections per template should be permitted.
+    data: { bool: false, two: 'second' }
+    template: |
+      {{^bool}}
+      * first
+      {{/bool}}
+      * {{two}}
+      {{^bool}}
+      * third
+      {{/bool}}
+    expected: |
+      * first
+      * second
+      * third
+
+  - name: Nested (Falsey)
+    desc: Nested falsey sections should have their contents rendered.
+    data: { bool: false }
+    template: "| A {{^bool}}B {{^bool}}C{{/bool}} D{{/bool}} E |"
+    expected: "| A B C D E |"
+
+  - name: Nested (Truthy)
+    desc: Nested truthy sections should be omitted.
+    data: { bool: true }
+    template: "| A {{^bool}}B {{^bool}}C{{/bool}} D{{/bool}} E |"
+    expected: "| A  E |"
+
+  - name: Context Misses
+    desc: Failed context lookups should be considered falsey.
+    data: { }
+    template: "[{{^missing}}Cannot find key 'missing'!{{/missing}}]"
+    expected: "[Cannot find key 'missing'!]"
+
+  # Dotted Names
+
+  - name: Dotted Names - Truthy
+    desc: Dotted names should be valid for Inverted Section tags.
+    data: { a: { b: { c: true } } }
+    template: '"{{^a.b.c}}Not Here{{/a.b.c}}" == ""'
+    expected: '"" == ""'
+
+  - name: Dotted Names - Falsey
+    desc: Dotted names should be valid for Inverted Section tags.
+    data: { a: { b: { c: false } } }
+    template: '"{{^a.b.c}}Not Here{{/a.b.c}}" == "Not Here"'
+    expected: '"Not Here" == "Not Here"'
+
+  - name: Dotted Names - Broken Chains
+    desc: Dotted names that cannot be resolved should be considered falsey.
+    data: { a: { } }
+    template: '"{{^a.b.c}}Not Here{{/a.b.c}}" == "Not Here"'
+    expected: '"Not Here" == "Not Here"'
+
+  # Whitespace Sensitivity
+
+  - name: Surrounding Whitespace
+    desc: Inverted sections should not alter surrounding whitespace.
+    data: { boolean: false }
+    template: " | {{^boolean}}\t|\t{{/boolean}} | \n"
+    expected: " | \t|\t | \n"
+
+  - name: Internal Whitespace
+    desc: Inverted should not alter internal whitespace.
+    data: { boolean: false }
+    template: " | {{^boolean}} {{! Important Whitespace }}\n {{/boolean}} | \n"
+    expected: " |  \n  | \n"
+
+  - name: Indented Inline Sections
+    desc: Single-line sections should not alter surrounding whitespace.
+    data: { boolean: false }
+    template: " {{^boolean}}NO{{/boolean}}\n {{^boolean}}WAY{{/boolean}}\n"
+    expected: " NO\n WAY\n"
+
+  - name: Standalone Lines
+    desc: Standalone lines should be removed from the template.
+    data: { boolean: false }
+    template: |
+      | This Is
+      {{^boolean}}
+      |
+      {{/boolean}}
+      | A Line
+    expected: |
+      | This Is
+      |
+      | A Line
+
+  - name: Standalone Indented Lines
+    desc: Standalone indented lines should be removed from the template.
+    data: { boolean: false }
+    template: |
+      | This Is
+        {{^boolean}}
+      |
+        {{/boolean}}
+      | A Line
+    expected: |
+      | This Is
+      |
+      | A Line
+
+  - name: Standalone Line Endings
+    desc: '"\r\n" should be considered a newline for standalone tags.'
+    data: { boolean: false }
+    template: "|\r\n{{^boolean}}\r\n{{/boolean}}\r\n|"
+    expected: "|\r\n|"
+
+  - name: Standalone Without Previous Line
+    desc: Standalone tags should not require a newline to precede them.
+    data: { boolean: false }
+    template: "  {{^boolean}}\n^{{/boolean}}\n/"
+    expected: "^\n/"
+
+  - name: Standalone Without Newline
+    desc: Standalone tags should not require a newline to follow them.
+    data: { boolean: false }
+    template: "^{{^boolean}}\n/\n  {{/boolean}}"
+    expected: "^\n/\n"
+
+  # Whitespace Insensitivity
+
+  - name: Padding
+    desc: Superfluous in-tag whitespace should be ignored.
+    data: { boolean: false }
+    template: '|{{^ boolean }}={{/ boolean }}|'
+    expected: '|=|'

--- a/src/test/resources/specs/partials.yml
+++ b/src/test/resources/specs/partials.yml
@@ -1,0 +1,109 @@
+overview: |
+  Partial tags are used to expand an external template into the current
+  template.
+
+  The tag's content MUST be a non-whitespace character sequence NOT containing
+  the current closing delimiter.
+
+  This tag's content names the partial to inject.  Set Delimiter tags MUST NOT
+  affect the parsing of a partial.  The partial MUST be rendered against the
+  context stack local to the tag.  If the named partial cannot be found, the
+  empty string SHOULD be used instead, as in interpolations.
+
+  Partial tags SHOULD be treated as standalone when appropriate.  If this tag
+  is used standalone, any whitespace preceding the tag should treated as
+  indentation, and prepended to each line of the partial before rendering.
+tests:
+  - name: Basic Behavior
+    desc: The greater-than operator should expand to the named partial.
+    data: { }
+    template: '"{{>text}}"'
+    partials: { text: 'from partial' }
+    expected: '"from partial"'
+
+  - name: Failed Lookup
+    desc: The empty string should be used when the named partial is not found.
+    data: { }
+    template: '"{{>text}}"'
+    partials: { }
+    expected: '""'
+
+  - name: Context
+    desc: The greater-than operator should operate within the current context.
+    data: { text: 'content' }
+    template: '"{{>partial}}"'
+    partials: { partial: '*{{text}}*' }
+    expected: '"*content*"'
+
+  - name: Recursion
+    desc: The greater-than operator should properly recurse.
+    data: { content: "X", nodes: [ { content: "Y", nodes: [] } ] }
+    template: '{{>node}}'
+    partials: { node: '{{content}}<{{#nodes}}{{>node}}{{/nodes}}>' }
+    expected: 'X<Y<>>'
+
+  # Whitespace Sensitivity
+
+  - name: Surrounding Whitespace
+    desc: The greater-than operator should not alter surrounding whitespace.
+    data: { }
+    template: '| {{>partial}} |'
+    partials: { partial: "\t|\t" }
+    expected: "| \t|\t |"
+
+  - name: Inline Indentation
+    desc: Whitespace should be left untouched.
+    data: { data: '|' }
+    template: "  {{data}}  {{> partial}}\n"
+    partials: { partial: ">\n>" }
+    expected: "  |  >\n>\n"
+
+  - name: Standalone Line Endings
+    desc: '"\r\n" should be considered a newline for standalone tags.'
+    data: { }
+    template: "|\r\n{{>partial}}\r\n|"
+    partials: { partial: ">" }
+    expected: "|\r\n>|"
+
+  - name: Standalone Without Previous Line
+    desc: Standalone tags should not require a newline to precede them.
+    data: { }
+    template: "  {{>partial}}\n>"
+    partials: { partial: ">\n>"}
+    expected: "  >\n  >>"
+
+  - name: Standalone Without Newline
+    desc: Standalone tags should not require a newline to follow them.
+    data: { }
+    template: ">\n  {{>partial}}"
+    partials: { partial: ">\n>" }
+    expected: ">\n  >\n  >"
+
+  - name: Standalone Indentation
+    desc: Each line of the partial should be indented before rendering.
+    data: { content: "<\n->" }
+    template: |
+      \
+       {{>partial}}
+      /
+    partials:
+      partial: |
+        |
+        {{{content}}}
+        |
+    expected: |
+      \
+       |
+       <
+      ->
+       |
+      /
+
+  # Whitespace Insensitivity
+
+  - name: Padding Whitespace
+    desc: Superfluous in-tag whitespace should be ignored.
+    data: { boolean: true }
+    template: "|{{> partial }}|"
+    partials: { partial: "[]" }
+    expected: '|[]|'

--- a/src/test/resources/specs/sections.yml
+++ b/src/test/resources/specs/sections.yml
@@ -1,0 +1,301 @@
+overview: |
+  Section tags and End Section tags are used in combination to wrap a section
+  of the template for iteration
+
+  These tags' content MUST be a non-whitespace character sequence NOT
+  containing the current closing delimiter; each Section tag MUST be followed
+  by an End Section tag with the same content within the same section.
+
+  This tag's content names the data to replace the tag.  Name resolution is as
+  follows:
+    1) Split the name on periods; the first part is the name to resolve, any
+    remaining parts should be retained.
+    2) Walk the context stack from top to bottom, finding the first context
+    that is a) a hash containing the name as a key OR b) an object responding
+    to a method with the given name.
+    3) If the context is a hash, the data is the value associated with the
+    name.
+    4) If the context is an object and the method with the given name has an
+    arity of 1, the method SHOULD be called with a String containing the
+    unprocessed contents of the sections; the data is the value returned.
+    5) Otherwise, the data is the value returned by calling the method with
+    the given name.
+    6) If any name parts were retained in step 1, each should be resolved
+    against a context stack containing only the result from the former
+    resolution.  If any part fails resolution, the result should be considered
+    falsey, and should interpolate as the empty string.
+  If the data is not of a list type, it is coerced into a list as follows: if
+  the data is truthy (e.g. `!!data == true`), use a single-element list
+  containing the data, otherwise use an empty list.
+
+  For each element in the data list, the element MUST be pushed onto the
+  context stack, the section MUST be rendered, and the element MUST be popped
+  off the context stack.
+
+  Section and End Section tags SHOULD be treated as standalone when
+  appropriate.
+tests:
+  - name: Truthy
+    desc: Truthy sections should have their contents rendered.
+    data: { boolean: true }
+    template: '"{{#boolean}}This should be rendered.{{/boolean}}"'
+    expected: '"This should be rendered."'
+
+  - name: Falsey
+    desc: Falsey sections should have their contents omitted.
+    data: { boolean: false }
+    template: '"{{#boolean}}This should not be rendered.{{/boolean}}"'
+    expected: '""'
+
+  - name: Null is falsey
+    desc: Null is falsey.
+    data: { "null": null }
+    template: '"{{#null}}This should not be rendered.{{/null}}"'
+    expected: '""'
+
+  - name: Context
+    desc: Objects and hashes should be pushed onto the context stack.
+    data: { context: { name: 'Joe' } }
+    template: '"{{#context}}Hi {{name}}.{{/context}}"'
+    expected: '"Hi Joe."'
+
+  - name: Parent contexts
+    desc: Names missing in the current context are looked up in the stack.
+    data: { a: "foo", b: "wrong", sec: { b: "bar" }, c : { d : "baz" } }
+    template: '"{{#sec}}{{a}}, {{b}}, {{c.d}}{{/sec}}"'
+    expected: '"foo, bar, baz"'
+
+  - name: Variable test
+    desc: |
+      Non-false sections have their value at the top of context,
+      accessible as {{.}} or through the parent context. This gives
+      a simple way to display content conditionally if a variable exists.
+    data: { foo: "bar" }
+    template: '"{{#foo}}{{.}} is {{foo}}{{/foo}}"'
+    expected: '"bar is bar"'
+
+  - name: List Contexts
+    desc: All elements on the context stack should be accessible within lists.
+    data:
+      tops:
+        - tname:
+            upper: "A"
+            lower: "a"
+          middles:
+            - mname: "1"
+              bottoms:
+                - bname: "x"
+                - bname: "y"
+    template: '{{#tops}}{{#middles}}{{tname.lower}}{{mname}}.{{#bottoms}}{{tname.upper}}{{mname}}{{bname}}.{{/bottoms}}{{/middles}}{{/tops}}'
+    expected: 'a1.A1x.A1y.'
+
+  - name: Deeply Nested Contexts
+    desc: All elements on the context stack should be accessible.
+    data:
+      a: { one: 1 }
+      b: { two: 2 }
+      c: { three: 3, d : { four : 4, five : 5 } }
+    template: |
+      {{#a}}
+      {{one}}
+      {{#b}}
+      {{one}}{{two}}{{one}}
+      {{#c}}
+      {{one}}{{two}}{{three}}{{two}}{{one}}
+      {{#d}}
+      {{one}}{{two}}{{three}}{{four}}{{three}}{{two}}{{one}}
+      {{#five}}
+      {{one}}{{two}}{{three}}{{four}}{{five}}{{four}}{{three}}{{two}}{{one}}
+      {{one}}{{two}}{{three}}{{four}}{{.}}6{{.}}{{four}}{{three}}{{two}}{{one}}
+      {{one}}{{two}}{{three}}{{four}}{{five}}{{four}}{{three}}{{two}}{{one}}
+      {{/five}}
+      {{one}}{{two}}{{three}}{{four}}{{three}}{{two}}{{one}}
+      {{/d}}
+      {{one}}{{two}}{{three}}{{two}}{{one}}
+      {{/c}}
+      {{one}}{{two}}{{one}}
+      {{/b}}
+      {{one}}
+      {{/a}}
+    expected: |
+      1
+      121
+      12321
+      1234321
+      123454321
+      12345654321
+      123454321
+      1234321
+      12321
+      121
+      1
+
+  - name: List
+    desc: Lists should be iterated; list items should visit the context stack.
+    data: { list: [ { item: 1 }, { item: 2 }, { item: 3 } ] }
+    template: '"{{#list}}{{item}}{{/list}}"'
+    expected: '"123"'
+
+  - name: Empty List
+    desc: Empty lists should behave like falsey values.
+    data: { list: [ ] }
+    template: '"{{#list}}Yay lists!{{/list}}"'
+    expected: '""'
+
+  - name: Doubled
+    desc: Multiple sections per template should be permitted.
+    data: { bool: true, two: 'second' }
+    template: |
+      {{#bool}}
+      * first
+      {{/bool}}
+      * {{two}}
+      {{#bool}}
+      * third
+      {{/bool}}
+    expected: |
+      * first
+      * second
+      * third
+
+  - name: Nested (Truthy)
+    desc: Nested truthy sections should have their contents rendered.
+    data: { bool: true }
+    template: "| A {{#bool}}B {{#bool}}C{{/bool}} D{{/bool}} E |"
+    expected: "| A B C D E |"
+
+  - name: Nested (Falsey)
+    desc: Nested falsey sections should be omitted.
+    data: { bool: false }
+    template: "| A {{#bool}}B {{#bool}}C{{/bool}} D{{/bool}} E |"
+    expected: "| A  E |"
+
+  - name: Context Misses
+    desc: Failed context lookups should be considered falsey.
+    data: { }
+    template: "[{{#missing}}Found key 'missing'!{{/missing}}]"
+    expected: "[]"
+
+  # Implicit Iterators
+
+  - name: Implicit Iterator - String
+    desc: Implicit iterators should directly interpolate strings.
+    data:
+      list: [ 'a', 'b', 'c', 'd', 'e' ]
+    template: '"{{#list}}({{.}}){{/list}}"'
+    expected: '"(a)(b)(c)(d)(e)"'
+
+  - name: Implicit Iterator - Integer
+    desc: Implicit iterators should cast integers to strings and interpolate.
+    data:
+      list: [ 1, 2, 3, 4, 5 ]
+    template: '"{{#list}}({{.}}){{/list}}"'
+    expected: '"(1)(2)(3)(4)(5)"'
+
+  - name: Implicit Iterator - Decimal
+    desc: Implicit iterators should cast decimals to strings and interpolate.
+    data:
+      list: [ 1.10, 2.20, 3.30, 4.40, 5.50 ]
+    template: '"{{#list}}({{.}}){{/list}}"'
+    expected: '"(1.1)(2.2)(3.3)(4.4)(5.5)"'
+
+  - name: Implicit Iterator - Array
+    desc: Implicit iterators should allow iterating over nested arrays.
+    data:
+      list: [ [1, 2, 3], ['a', 'b', 'c'] ]
+    template: '"{{#list}}({{#.}}{{.}}{{/.}}){{/list}}"'
+    expected: '"(123)(abc)"'
+
+  # Dotted Names
+
+  - name: Dotted Names - Truthy
+    desc: Dotted names should be valid for Section tags.
+    data: { a: { b: { c: true } } }
+    template: '"{{#a.b.c}}Here{{/a.b.c}}" == "Here"'
+    expected: '"Here" == "Here"'
+
+  - name: Dotted Names - Falsey
+    desc: Dotted names should be valid for Section tags.
+    data: { a: { b: { c: false } } }
+    template: '"{{#a.b.c}}Here{{/a.b.c}}" == ""'
+    expected: '"" == ""'
+
+  - name: Dotted Names - Broken Chains
+    desc: Dotted names that cannot be resolved should be considered falsey.
+    data: { a: { } }
+    template: '"{{#a.b.c}}Here{{/a.b.c}}" == ""'
+    expected: '"" == ""'
+
+  # Whitespace Sensitivity
+
+  - name: Surrounding Whitespace
+    desc: Sections should not alter surrounding whitespace.
+    data: { boolean: true }
+    template: " | {{#boolean}}\t|\t{{/boolean}} | \n"
+    expected: " | \t|\t | \n"
+
+  - name: Internal Whitespace
+    desc: Sections should not alter internal whitespace.
+    data: { boolean: true }
+    template: " | {{#boolean}} {{! Important Whitespace }}\n {{/boolean}} | \n"
+    expected: " |  \n  | \n"
+
+  - name: Indented Inline Sections
+    desc: Single-line sections should not alter surrounding whitespace.
+    data: { boolean: true }
+    template: " {{#boolean}}YES{{/boolean}}\n {{#boolean}}GOOD{{/boolean}}\n"
+    expected: " YES\n GOOD\n"
+
+  - name: Standalone Lines
+    desc: Standalone lines should be removed from the template.
+    data: { boolean: true }
+    template: |
+      | This Is
+      {{#boolean}}
+      |
+      {{/boolean}}
+      | A Line
+    expected: |
+      | This Is
+      |
+      | A Line
+
+  - name: Indented Standalone Lines
+    desc: Indented standalone lines should be removed from the template.
+    data: { boolean: true }
+    template: |
+      | This Is
+        {{#boolean}}
+      |
+        {{/boolean}}
+      | A Line
+    expected: |
+      | This Is
+      |
+      | A Line
+
+  - name: Standalone Line Endings
+    desc: '"\r\n" should be considered a newline for standalone tags.'
+    data: { boolean: true }
+    template: "|\r\n{{#boolean}}\r\n{{/boolean}}\r\n|"
+    expected: "|\r\n|"
+
+  - name: Standalone Without Previous Line
+    desc: Standalone tags should not require a newline to precede them.
+    data: { boolean: true }
+    template: "  {{#boolean}}\n#{{/boolean}}\n/"
+    expected: "#\n/"
+
+  - name: Standalone Without Newline
+    desc: Standalone tags should not require a newline to follow them.
+    data: { boolean: true }
+    template: "#{{#boolean}}\n/\n  {{/boolean}}"
+    expected: "#\n/\n"
+
+  # Whitespace Insensitivity
+
+  - name: Padding
+    desc: Superfluous in-tag whitespace should be ignored.
+    data: { boolean: true }
+    template: '|{{# boolean }}={{/ boolean }}|'
+    expected: '|=|'

--- a/src/test/resources/specs/~additional.yml
+++ b/src/test/resources/specs/~additional.yml
@@ -7,6 +7,24 @@ tests:
     template: "  {{>node}}"
     partials: { node: "|\n{{content}}\n|\n{{#nodes}}\n  {{>node}}\n{{/nodes}}\n" }
     expected: "  |\n  X\n  |\n    |\n    Y\n    |\n"
+  - name: Partials
+    desc: Indentation in indirect recursion
+    data: { content: "X", nodes: [ { content: "Y", nodes: [] } ] }
+    template: "  {{>node}}"
+    partials:
+      node: "|\n{{content}}\n|\n{{#nodes}}\n  {{>node2}}\n{{/nodes}}\n"
+      node2: "  {{>node}}"
+    expected: "  |\n  X\n  |\n      |\n      Y\n      |\n"
+  - name: Partials
+    desc: Indentation with multiple partial
+    data:
+      content: "X"
+      next: { content: "Y" }
+    template: "  {{>node}}"
+    partials:
+      node: "|\n{{content}}\n|\n  {{>node2}}\n"
+      node2: "|\n{{#next}}{{content}}\n{{/next}}|"
+    expected: "  |\n  X\n  |\n    |\n    Y\n    |"
   - name: Special names
     desc: List values have additional fields
     data:

--- a/src/test/resources/specs/~additional.yml
+++ b/src/test/resources/specs/~additional.yml
@@ -1,0 +1,21 @@
+overview: |
+  Additional test specific to this implementation.
+tests:
+  - name: Partials
+    desc: Indentation can recurse
+    data: { content: "X", nodes: [ { content: "Y", nodes: [] } ] }
+    template: "  {{>node}}"
+    partials: { node: "|\n{{content}}\n|\n{{#nodes}}\n  {{>node}}\n{{/nodes}}\n" }
+    expected: "  |\n  X\n  |\n    |\n    Y\n    |\n"
+  - name: Special names
+    desc: List values have additional fields
+    data:
+      list: [ "elt1", "elt2", "elt3" ]
+    template: |
+      {{#list}}
+      {{.}} first={{first}} last={{last}} index={{index}} index1={{index1}}
+      {{/list}}
+    expected: |
+      elt1 first=true last=false index=0 index1=1
+      elt2 first=false last=false index=1 index1=2
+      elt3 first=false last=true index=2 index1=3


### PR DESCRIPTION
Hi Peter

more evening work :-D
now passing all basic tests.

Note that in addition to management of whitespace there is a behaviour change on sections containing a value referring to a single map. Previous behaviour was iterating over the map entries while spec says the map is a single object. This was causing section.yaml/deeply nested context to fail.

Regards
Noel

